### PR TITLE
System.Text.Json允许使用一个全局默认的序列化配置，用于统一和Newtonsoft.Json有差异的行为

### DIFF
--- a/src/TouchSocket.Core/Serialization/SerializeConvert.cs
+++ b/src/TouchSocket.Core/Serialization/SerializeConvert.cs
@@ -13,6 +13,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Text.Json;
 using System.Xml.Serialization;
 
 namespace TouchSocket.Core;
@@ -380,13 +381,18 @@ public static partial class SerializeConvert
     #region Json序列化和反序列化
 
     /// <summary>
+    /// 全局默认Json序列化选项
+    /// </summary>
+    public static JsonSerializerOptions DefaultJsonSerializerOptions { set; get; } = null;
+
+    /// <summary>
     /// 转换为Json
     /// </summary>
     /// <param name="item"></param>
     /// <returns></returns>
     public static string ToJsonString(this object item)
     {
-        return System.Text.Json.JsonSerializer.Serialize(item);
+        return System.Text.Json.JsonSerializer.Serialize(item, DefaultJsonSerializerOptions);
     }
 
     /// <summary>
@@ -394,10 +400,11 @@ public static partial class SerializeConvert
     /// </summary>
     /// <param name="json"></param>
     /// <param name="type"></param>
+    /// <param name="jsonSerializerOptions"></param>
     /// <returns></returns>
-    public static object FromJsonString(this string json, Type type)
+    public static object FromJsonString(this string json, Type type, JsonSerializerOptions jsonSerializerOptions = null)
     {
-        return System.Text.Json.JsonSerializer.Deserialize(json, type);
+        return System.Text.Json.JsonSerializer.Deserialize(json, type, jsonSerializerOptions ?? DefaultJsonSerializerOptions);
     }
 
     /// <summary>
@@ -406,9 +413,9 @@ public static partial class SerializeConvert
     /// <typeparam name="T"></typeparam>
     /// <param name="json"></param>
     /// <returns></returns>
-    public static T FromJsonString<T>(this string json)
+    public static T FromJsonString<T>(this string json, JsonSerializerOptions jsonSerializerOptions = null)
     {
-        return (T)FromJsonString(json, typeof(T));
+        return (T)FromJsonString(json, typeof(T), jsonSerializerOptions);
     }
 
     /// <summary>


### PR DESCRIPTION
System.Text.Json有一些行为和Newtonsoft.Json不一样，最明显的是字符串到数组的转换，以及Json内部有注释的处理。
前者需要自定义一个转换器，后者需要一个配置。
这些都可以按照个人习惯添加，但是找不到一个传配置的入口。
因为当前代码大量使用了SerializeConvert.FromJsonString()，不太想修改，所以还是希望能全局配置解决。
此外，我一直想对时间的格式做设定，加入这个全局配置，正好也能解决这个问题。