### PR TITLE
Discussion: Preserving Empty HTTP Header Values vs. Dropping Them

### DIFF
--- a/src/TouchSocket.Http/Common/HttpBase.cs
+++ b/src/TouchSocket.Http/Common/HttpBase.cs
@@ -241,7 +241,7 @@ public abstract class HttpBase : IRequestInfo
         var keySpan = line.Slice(0, colonIndex);
         var valueSpan = TouchSocketHttpUtility.TrimWhitespace(line.Slice(colonIndex + 1));
 
-        if (keySpan.IsEmpty || valueSpan.IsEmpty)
+        if (keySpan.IsEmpty)
         {
             return;
         }


### PR DESCRIPTION
This PR changes the behavior of header parsing in `HttpBase`:

* **Before**: headers with empty values (e.g. `X-Test:`) are **dropped**
* **After**: headers with empty values are **preserved as empty strings**

## Discussion

| Product/Library | Not sent    | Sent but empty                        |
| --------------- | ----------- | ------------------------------------- |
| ASP.NET Core    | `null`      | `""`                                  |
| Node.js         | `undefined` | `''`                                  |
| Go (`net/http`) | `""`        | `""`                                  |
| Nginx           | -           | Drops when forwarding upstream        |
| Envoy           | -           | Preserves at the protocol level       |
| HAProxy         | -           | Generally preserves, but configurable |

Benefits:

* Preserving empty headers **makes** them distinguishable from missing headers

Drawbacks:

* If a server checks for the presence of a header without considering empty values, it may lead to unexpected behavior (e.g. treating `X-Test:` as valid when it should be considered missing)

---

So, a decision needs to be made here.