### PR TITLE
修复 WebApi OpenAPI Schema 生成不符合规范的问题

### DIFF
--- a/src/TouchSocket.WebApi/JsonConverters/OpenApiJsonSerializerContext.cs
+++ b/src/TouchSocket.WebApi/JsonConverters/OpenApiJsonSerializerContext.cs
@@ -18,7 +18,7 @@ namespace TouchSocket.WebApi;
 [JsonSourceGenerationOptions(
     WriteIndented = true,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    Converters = [typeof(JsonStringEnumConverter<OpenApiDataTypes>)])]
+    Converters = [typeof(OpenApiDataTypesJsonConverter)])]
 [JsonSerializable(typeof(OpenApiRoot))]
 [JsonSerializable(typeof(OpenApiInfo))]
 [JsonSerializable(typeof(OpenApiPath))]

--- a/src/TouchSocket.WebApi/OpenApi/OpenApiDataTypes.cs
+++ b/src/TouchSocket.WebApi/OpenApi/OpenApiDataTypes.cs
@@ -10,6 +10,7 @@
 //  感谢您的下载和使用
 //------------------------------------------------------------------------------
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace TouchSocket.WebApi.OpenApi;
@@ -17,7 +18,7 @@ namespace TouchSocket.WebApi.OpenApi;
 /// <summary>
 /// 表示 OpenAPI 规范中支持的数据类型。
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter<OpenApiDataTypes>))]
+[JsonConverter(typeof(OpenApiDataTypesJsonConverter))]
 public enum OpenApiDataTypes
 {
     /// <summary>
@@ -79,4 +80,28 @@ public enum OpenApiDataTypes
     /// Any
     /// </summary>
     Any
+}
+
+/// <summary>
+/// 按 OpenAPI 规范要求使用小写名称序列化数据类型。
+/// </summary>
+internal sealed class OpenApiDataTypesJsonConverter : JsonConverter<OpenApiDataTypes>
+{
+    /// <inheritdoc/>
+    public override OpenApiDataTypes Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (Enum.TryParse<OpenApiDataTypes>(value, true, out var dataType))
+        {
+            return dataType;
+        }
+
+        throw new JsonException($"不支持的 OpenAPI 数据类型：{value}");
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, OpenApiDataTypes value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString().ToLowerInvariant());
+    }
 }

--- a/src/TouchSocket.WebApi/OpenApi/OpenApiProperty.cs
+++ b/src/TouchSocket.WebApi/OpenApi/OpenApiProperty.cs
@@ -54,4 +54,16 @@ public class OpenApiProperty
     /// </summary>
     [JsonPropertyName("type")]
     public OpenApiDataTypes? Type { get; set; }
+
+    /// <summary>
+    /// 获取或设置枚举类型的可选值列表。
+    /// </summary>
+    [JsonPropertyName("enum")]
+    public long[] Enum { get; set; }
+
+    /// <summary>
+    /// 获取或设置属性是否允许为空。
+    /// </summary>
+    [JsonPropertyName("nullable")]
+    public bool? Nullable { get; set; }
 }

--- a/src/TouchSocket.WebApi/OpenApi/OpenApiSchema.cs
+++ b/src/TouchSocket.WebApi/OpenApi/OpenApiSchema.cs
@@ -54,4 +54,10 @@ public class OpenApiSchema
     /// </summary>
     [JsonPropertyName("enum")]
     public long[] Enum { get; set; }
+
+    /// <summary>
+    /// 获取或设置 Schema 是否允许为空。
+    /// </summary>
+    [JsonPropertyName("nullable")]
+    public bool? Nullable { get; set; }
 }

--- a/src/TouchSocket.WebApi/Plugins/OpenApiPlugin.cs
+++ b/src/TouchSocket.WebApi/Plugins/OpenApiPlugin.cs
@@ -133,6 +133,16 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "OpenApi内部使用，相信动态代码是有效的")]
     private void AddSchemaType(Type type, in List<Type> types)
     {
+        if (type is null)
+        {
+            return;
+        }
+
+        if (type.IsNullableType(out var actualType))
+        {
+            type = actualType;
+        }
+
         if (type.IsArray)
         {
             type = type.GetElementType();
@@ -259,6 +269,7 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
                 {
                     var openApiProperty = this.CreateProperty(item.Parameter.Type, item.Parameter.ParameterInfo.GetDescription());
                     properties.Add(this.GetOpenApiParameterName(item.Parameter.ParameterInfo), openApiProperty);
+                    this.AddSchemaType(item.Parameter.Type, schemaTypeList);
                 }
 
                 content.Schema = new OpenApiSchema()
@@ -367,8 +378,22 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
     private OpenApiProperty CreateProperty(Type type, string description)
     {
         var openApiProperty = new OpenApiProperty();
+        if (type.IsNullableType(out var actualType))
+        {
+            type = actualType;
+            openApiProperty.Nullable = true;
+        }
+
         var dataTypes = this.ParseDataTypes(type);
         openApiProperty.Description = description;
+
+        if (type.IsEnum)
+        {
+            openApiProperty.Type = OpenApiDataTypes.Integer;
+            openApiProperty.Enum = GetEnumValues(type);
+            openApiProperty.Format = this.GetSchemaFormat(type);
+            return openApiProperty;
+        }
 
         switch (dataTypes)
         {
@@ -386,7 +411,31 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
                 break;
 
             case OpenApiDataTypes.Object:
-                openApiProperty.Ref = $"#/components/schemas/{type.Name}";
+                openApiProperty.Ref = $"#/components/schemas/{this.GetSchemaName(type)}";
+                return openApiProperty;
+
+            case OpenApiDataTypes.Binary:
+                openApiProperty.Type = OpenApiDataTypes.String;
+                openApiProperty.Format = "binary";
+                return openApiProperty;
+
+            case OpenApiDataTypes.BinaryCollection:
+                openApiProperty.Type = OpenApiDataTypes.Array;
+                openApiProperty.Items = new OpenApiProperty
+                {
+                    Type = OpenApiDataTypes.String,
+                    Format = "binary"
+                };
+                return openApiProperty;
+
+            case OpenApiDataTypes.Record:
+            case OpenApiDataTypes.Struct:
+                openApiProperty.Type = OpenApiDataTypes.Object;
+                return openApiProperty;
+
+            case OpenApiDataTypes.Tuple:
+                openApiProperty.Type = OpenApiDataTypes.Array;
+                openApiProperty.Items = new OpenApiProperty();
                 break;
         }
 
@@ -398,7 +447,21 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
     private OpenApiSchema CreateSchema(Type type)
     {
         var schema = new OpenApiSchema();
+        if (type.IsNullableType(out var actualType))
+        {
+            type = actualType;
+            schema.Nullable = true;
+        }
+
         var dataTypes = this.ParseDataTypes(type);
+
+        if (type.IsEnum)
+        {
+            schema.Enum = GetEnumValues(type);
+            schema.Type = OpenApiDataTypes.Integer;
+            schema.Format = this.GetSchemaFormat(type);
+            return schema;
+        }
 
         switch (dataTypes)
         {
@@ -415,23 +478,32 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
                 break;
 
             case OpenApiDataTypes.Object:
-                if (type.IsEnum)
-                {
-                    var list = new List<long>();
-                    foreach (var item in Enum.GetValues(type))
-                    {
-                        list.Add(Convert.ToInt64(item));
-                    }
+                schema.Ref = $"#/components/schemas/{this.GetSchemaName(type)}";
+                return schema;
 
-                    schema.Enum = list.ToArray();
-                    schema.Type = OpenApiDataTypes.Integer;
-                }
-                else
-                {
-                    schema.Ref = $"#/components/schemas/{this.GetSchemaName(type)}";
-                }
+            case OpenApiDataTypes.Binary:
+                schema.Type = OpenApiDataTypes.String;
+                schema.Format = "binary";
+                return schema;
 
-                break;
+            case OpenApiDataTypes.BinaryCollection:
+                schema.Type = OpenApiDataTypes.Array;
+                schema.Items = new OpenApiSchema
+                {
+                    Type = OpenApiDataTypes.String,
+                    Format = "binary"
+                };
+                return schema;
+
+            case OpenApiDataTypes.Record:
+            case OpenApiDataTypes.Struct:
+                schema.Type = OpenApiDataTypes.Object;
+                return schema;
+
+            case OpenApiDataTypes.Tuple:
+                schema.Type = OpenApiDataTypes.Array;
+                schema.Items = new OpenApiSchema();
+                return schema;
         }
 
         schema.Format = this.GetSchemaFormat(type);
@@ -451,21 +523,25 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
 
         foreach (var type in types)
         {
-            var schema = this.CreateSchema(type);
+            var schema = new OpenApiSchema
+            {
+                Type = OpenApiDataTypes.Object
+            };
             var properties = new Dictionary<string, OpenApiProperty>();
 
             foreach (var propertyInfo in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
             {
-                if (properties.ContainsKey(propertyInfo.Name))
+                var propertyName = GetOpenApiPropertyName(propertyInfo);
+                if (properties.ContainsKey(propertyName))
                 {
                     if (propertyInfo.DeclaringType == type)
                     {
-                        properties[propertyInfo.Name] = this.CreateProperty(propertyInfo.PropertyType, propertyInfo.GetDescription());
+                        properties[propertyName] = this.CreateProperty(propertyInfo.PropertyType, propertyInfo.GetDescription());
                     }
                 }
                 else
                 {
-                    properties.Add(propertyInfo.Name, this.CreateProperty(propertyInfo.PropertyType, propertyInfo.GetDescription()));
+                    properties.Add(propertyName, this.CreateProperty(propertyInfo.PropertyType, propertyInfo.GetDescription()));
                 }
             }
 
@@ -527,6 +603,16 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
 
     private string GetSchemaFormat(Type type)
     {
+        if (type.IsNullableType(out var actualType))
+        {
+            type = actualType;
+        }
+
+        if (type == typeof(Guid))
+        {
+            return "uuid";
+        }
+
         return Type.GetTypeCode(type) switch
         {
             TypeCode.SByte or TypeCode.Byte or TypeCode.Int16 or TypeCode.UInt16 or TypeCode.Int32 or TypeCode.UInt32 => "int32",
@@ -535,7 +621,7 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
             TypeCode.Double or TypeCode.Decimal => "double",
             TypeCode.DateTime => "date-time",
             TypeCode.Boolean or TypeCode.Char or TypeCode.String => default,
-            _ => "object",
+            _ => default,
         };
     }
 
@@ -554,6 +640,25 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
 
         stringBuilder.Append(type.Name.Substring(0, type.Name.IndexOf('`')));
         return stringBuilder.ToString();
+    }
+
+    private static string GetOpenApiPropertyName(PropertyInfo propertyInfo)
+    {
+        var attribute = propertyInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonPropertyNameAttribute>();
+        return attribute?.Name ?? JsonNamingPolicy.CamelCase.ConvertName(propertyInfo.Name);
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "OpenApi内部使用，相信动态代码是有效的")]
+    private static long[] GetEnumValues(Type type)
+    {
+        var values = Enum.GetValues(type);
+        var result = new long[values.Length];
+        for (var i = 0; i < values.Length; i++)
+        {
+            result[i] = Convert.ToInt64(values.GetValue(i));
+        }
+
+        return result;
     }
 
     private static bool IsFormFileCollection(Type type)
@@ -604,6 +709,7 @@ public class OpenApiPlugin : PluginBase, IHttpPlugin
             _ when type.IsDecimal() => OpenApiDataTypes.Number,
             _ when typeof(bool).IsAssignableFrom(type) => OpenApiDataTypes.Boolean,
             _ when typeof(DateTime).IsAssignableFrom(type) || typeof(DateTimeOffset).IsAssignableFrom(type) => OpenApiDataTypes.String,
+            _ when typeof(Guid).IsAssignableFrom(type) || typeof(Uri).IsAssignableFrom(type) => OpenApiDataTypes.String,
             _ when typeof(IFormFile).IsAssignableFrom(type) => OpenApiDataTypes.Binary,
             _ when IsFormFileCollection(type) => OpenApiDataTypes.BinaryCollection,
             _ when type.IsDictionary() => OpenApiDataTypes.Record,


### PR DESCRIPTION
## 问题说明

`UseOpenApi` 生成的 `openapi.json` 无法被 Swagger Editor 等标准 OpenAPI 工具正常解析，主要存在以下问题：

- Schema 的 `type` 被输出为 `String`、`Integer`、`Array` 等大写值，不符合 OpenAPI 规范。
- `components.schemas` 中的对象 Schema 使用 `$ref` 指向自身，形成循环引用。
- 枚举、可空枚举和泛型类型可能生成未定义的 `$ref`。
- 泛型 Schema 的定义名称与引用名称不一致。
- Schema 属性名使用 C# PascalCase，与默认 JSON camelCase 输出不一致。
- 文件、文件集合、字典、元组、结构体等类型缺少正确的 OpenAPI 表达。

## 修改内容

- 使用专用 JSON Converter 将 OpenAPI 数据类型序列化为小写。
- Component Schema 直接生成为 `object + properties`，避免自引用。
- 统一通过 `GetSchemaName` 生成泛型 Schema 名称和引用。
- 正确处理枚举和可空枚举：
  - 输出 `type: integer`
  - 输出枚举值列表
  - 可空类型输出 `nullable: true`
- 补充二进制文件、文件集合、字典、元组和结构体类型处理。
- 补充 `Guid` 和 `Uri` 类型处理。
- 注册 multipart/form-data 中使用的复杂类型。
- Schema 属性名默认使用 camelCase。
- 优先使用属性上的 `[JsonPropertyName]` 显式名称。

## 修复示例

修复前：

```json
{
  "$ref": "#/components/schemas/Variable",
  "properties": {
    "Name": {
      "type": "String"
    }
  }
}
```

修复后：

```json
{
  "type": "object",
  "properties": {
    "name": {
      "type": "string"
    }
  }
}
```