### PR TITLE
net472使用ssl超时，参考mono的修复

### DIFF
--- a/src/TouchSocket/Components/Core/TaskToApm.cs
+++ b/src/TouchSocket/Components/Core/TaskToApm.cs
@@ -1,0 +1,105 @@
+using System.IO;
+using System.Diagnostics.Contracts;
+
+namespace System.Threading.Tasks;
+
+/// <summary>
+/// 参考Mono的Ssl实现
+/// https://github.com/mono/mono/pull/19476/changes
+/// </summary>
+internal static class TaskToApm
+{
+    public static IAsyncResult Begin(Task task, AsyncCallback callback, object state)
+    {
+        Contract.Requires(task != null);
+
+        IAsyncResult asyncResult;
+        if (task.IsCompleted)
+        {
+            asyncResult = new TaskWrapperAsyncResult(task, state, completedSynchronously: true);
+            if (callback != null)
+                callback(asyncResult);
+        }
+        else
+        {
+            asyncResult = task.AsyncState == state ? task : new TaskWrapperAsyncResult(task, state, completedSynchronously: false);
+            if (callback != null)
+                InvokeCallbackWhenTaskCompletes(task, callback, asyncResult);
+        }
+        return asyncResult;
+    }
+
+    public static void End(IAsyncResult asyncResult)
+    {
+        Task task;
+
+        var twar = asyncResult as TaskWrapperAsyncResult;
+        if (twar != null)
+        {
+            task = twar.Task;
+            Contract.Assert(task != null, "TaskWrapperAsyncResult should never wrap a null Task.");
+        }
+        else
+        {
+            task = asyncResult as Task;
+        }
+
+        if (task == null)
+            throw new ArgumentNullException(nameof(task), "WrongAsyncResult");
+        task.GetAwaiter().GetResult();
+    }
+
+    public static TResult End<TResult>(IAsyncResult asyncResult)
+    {
+        Task<TResult> task;
+
+        var twar = asyncResult as TaskWrapperAsyncResult;
+        if (twar != null)
+        {
+            task = twar.Task as Task<TResult>;
+            Contract.Assert(twar.Task != null, "TaskWrapperAsyncResult should never wrap a null Task.");
+        }
+        else
+        {
+            task = asyncResult as Task<TResult>;
+        }
+
+        if (task == null)
+            throw new ArgumentNullException(nameof(task), "WrongAsyncResult");
+        return task.GetAwaiter().GetResult();
+    }
+
+    private static void InvokeCallbackWhenTaskCompletes(Task antecedent, AsyncCallback callback, IAsyncResult asyncResult)
+    {
+        Contract.Requires(antecedent != null);
+        Contract.Requires(callback != null);
+        Contract.Requires(asyncResult != null);
+
+        antecedent.ConfigureAwait(continueOnCapturedContext: false)
+                  .GetAwaiter()
+                  .OnCompleted(() => callback(asyncResult));
+
+    }
+
+    private sealed class TaskWrapperAsyncResult : IAsyncResult
+    {
+        internal readonly Task Task;
+        private readonly object m_state;
+        private readonly bool m_completedSynchronously;
+
+        internal TaskWrapperAsyncResult(Task task, object state, bool completedSynchronously)
+        {
+            Contract.Requires(task != null);
+            Contract.Requires(!completedSynchronously || task.IsCompleted, "If completedSynchronously is true, the task must be completed.");
+
+            this.Task = task;
+            m_state = state;
+            m_completedSynchronously = completedSynchronously;
+        }
+
+        object IAsyncResult.AsyncState { get { return m_state; } }
+        bool IAsyncResult.CompletedSynchronously { get { return m_completedSynchronously; } }
+        bool IAsyncResult.IsCompleted { get { return this.Task.IsCompleted; } }
+        WaitHandle IAsyncResult.AsyncWaitHandle { get { return ((IAsyncResult)this.Task).AsyncWaitHandle; } }
+    }
+}

--- a/src/TouchSocket/Components/Core/TransportStream.cs
+++ b/src/TouchSocket/Components/Core/TransportStream.cs
@@ -12,6 +12,7 @@
 
 using System.Buffers;
 using System.IO.Pipelines;
+using System.Threading;
 
 namespace TouchSocket.Sockets;
 
@@ -80,6 +81,18 @@ public class TransportStream : Stream
     {
         return this.ReadAsync(buffer, offset, count).GetAwaiter().GetResult();
     }
+    /// <inheritdoc/>
+    public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+    {
+        return TaskToApm.Begin(this.ReadAsync(buffer, offset, count, CancellationToken.None), callback, state);
+    }
+
+    /// <inheritdoc/>
+    public override int EndRead(IAsyncResult asyncResult)
+    {
+        return TaskToApm.End<int>(asyncResult);
+    }
+
 
     /// <inheritdoc/>
     public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -178,6 +191,17 @@ public class TransportStream : Stream
     public override void Write(byte[] buffer, int offset, int count)
     {
         this.WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
+    }
+    /// <inheritdoc/>
+    public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+    {
+        return TaskToApm.Begin(this.WriteAsync(buffer, offset, count, CancellationToken.None), callback, state);
+    }
+
+    /// <inheritdoc/>
+    public override void EndWrite(IAsyncResult asyncResult)
+    {
+        TaskToApm.End(asyncResult);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
tcp dmtp 使用ssl访问服务端超时，查找发现之前mono也出现过类似的情况
https://github.com/mono/mono/pull/19476/changes
https://github.com/mono/mono/issues/18865
https://github.com/dotnet/runtime/issues/33447
抄一份修复方案，改上去后问题已经不会出现
可重现的demo 
https://github.com/zhangzw218/TouchSocket/tree/ssl_net472_dmtp_timeout